### PR TITLE
Update ConnectedLivingSpace.cfg

### DIFF
--- a/plugins/ConnectedLivingSpace/Distribution/GameData/ConnectedLivingSpace/Localization/ConnectedLivingSpace.cfg
+++ b/plugins/ConnectedLivingSpace/Distribution/GameData/ConnectedLivingSpace/Localization/ConnectedLivingSpace.cfg
@@ -1,7 +1,7 @@
-﻿Localization
+Localization
 {
-	en-us
-	{
+  en-us
+  {
     #clsloc_001 = Connected Living Space
     #clsloc_002 = Options
     #clsloc_003 = Click to view/edit options
@@ -45,7 +45,7 @@
     #clsloc_041 = Parts
   }
   es-es
-	{
+  {
     #clsloc_001 = Habitaciones Conectadas
     #clsloc_002 = Opciones
     #clsloc_003 = Click para ver/editar opciones
@@ -87,5 +87,49 @@
     #clsloc_039 = Nodo de Compuerta
     #clsloc_040 = Cuenta de Partes con Espacio Seleccionadas
     #clsloc_041 = Partes
- 	}
+  }
+  ru
+  {
+    #clsloc_001 = Connected Living Space
+    #clsloc_002 = Настройки
+    #clsloc_003 = Нажмите для просмотра/редактирования настроек
+    #clsloc_004 = Living Space
+    #clsloc_005 = Название
+    #clsloc_006 = Обновить
+    #clsloc_007 = Вместимость
+    #clsloc_008 = Экипаж
+    #clsloc_009 = No current vessel
+    #clsloc_010 = Разрешить все перемещения экипажа\n(поведение игры по-умолчанию)
+    #clsloc_011 = Включить возможность изменения проходимости блоков\n(Необходим перезапуск игры)
+    #clsloc_012 = Использовать "Blizzy's Toolbar" вместо стокового
+    #clsloc_013 = CLS - Этот модуль либо полон, либо до него нельзя добраться изнутри
+    #clsloc_014 = "Connected Living Space" препятствует перемещению
+    #clsloc_015 = и
+    #clsloc_016 = не в одном жилом пространстве
+    #clsloc_017 = Да
+    #clsloc_018 = Нет
+    #clsloc_019 = Все
+    #clsloc_020 = Нет
+    #clsloc_021 = Проходимый модуль
+    #clsloc_022 = Crewable
+    #clsloc_023 = Непроходимые ноды
+    #clsloc_024 = Проходимые ноды
+    #clsloc_025 = Проходимость, если радиально-присоединён к другому модулю
+    #clsloc_026 = Проходимость других радиально-присоединённых модулей к этому
+    #clsloc_027 = CLS Проходимый модуль: Нет
+    #clsloc_028 = CLS Проходимый модуль: Да
+    #clsloc_029 = CLS Прох. если радиал.прис-н: Нет
+    #clsloc_030 = CLS Прох. если радиал.прис-н: Да
+    #clsloc_031 = CLS Прох. других радиал.прис-х:Нет
+    #clsloc_032 = CLS Прох. других радиал.прис-х: Да
+    #clsloc_033 = Открыто
+    #clsloc_034 = Закрыто
+    #clsloc_035 = Состояние люка
+    #clsloc_036 = Открыть люк
+    #clsloc_037 = Закрыть люк
+    #clsloc_038 = Has Hatch
+    #clsloc_039 = Hatch Node
+    #clsloc_040 = Кол-во модулей
+    #clsloc_041 = Модули
+  }
 }


### PR DESCRIPTION
Bug report from [forum](https://forum.kerbalspaceprogram.com/index.php?/topic/109972-130-connected-living-space-v1253-1-jun-2017-localization/&do=findComment&comment=3095991):
> In the right-click menu in the VAB (at the very least), for 'CLS Passable' 'No' means it's passable, and 'Yes' means it isn't passable.
> Took me a while to figure out what was going on there.

 I fixed that at localization file and added beta for russian, but it isn't work for  "Connected Living Space" info-block for parts at VAB.

I tried change English string for 

`#clsloc_025 = Pass when Surface Attached`

but text wasn't changed at game, so I think they aren't connected.

It's same for "Docking Hatch" info-block. And "Docking Hatch" string absents at .cfg.


[printscreen](https://user-images.githubusercontent.com/12796450/30833997-e5362656-a259-11e7-840e-eac0970c9e01.png)
